### PR TITLE
MZ記事ブックマークAPI定義

### DIFF
--- a/components/parameters/mzArticleId.yml
+++ b/components/parameters/mzArticleId.yml
@@ -1,0 +1,7 @@
+in: path
+name: mzArticleId
+required: true
+schema:
+  type: integer
+  format: int64
+description: ID of the article

--- a/components/responses/BadRequest.yml
+++ b/components/responses/BadRequest.yml
@@ -1,0 +1,5 @@
+description: Bad Request
+content:
+  application/json:
+    schema:
+      $ref: "../schemas/Error.yml"

--- a/components/responses/Forbidden.yml
+++ b/components/responses/Forbidden.yml
@@ -1,0 +1,5 @@
+description: Forbidden
+content:
+  application/json:
+    schema:
+      $ref: "../schemas/Error.yml"

--- a/components/responses/InternalServerError.yml
+++ b/components/responses/InternalServerError.yml
@@ -1,0 +1,5 @@
+description: Internal Server Error
+content:
+  application/json:
+    schema:
+      $ref: "../schemas/Error.yml"

--- a/components/responses/NotFound.yml
+++ b/components/responses/NotFound.yml
@@ -1,0 +1,5 @@
+description: Not Found
+content:
+  application/json:
+    schema:
+      $ref: "../schemas/Error.yml"

--- a/components/responses/Unauthorized.yml
+++ b/components/responses/Unauthorized.yml
@@ -1,0 +1,5 @@
+description: Unauthorized
+content:
+  application/json:
+    schema:
+      $ref: "../schemas/Error.yml"

--- a/components/schemas/Error.yml
+++ b/components/schemas/Error.yml
@@ -1,0 +1,7 @@
+type: object
+properties:
+  code:
+    type: integer
+    format: int32
+  message:
+    type: string

--- a/components/schemas/Error.yml
+++ b/components/schemas/Error.yml
@@ -5,3 +5,15 @@ properties:
     format: int32
   message:
     type: string
+  errors:
+    type: object
+    additionalProperties:
+      type: object
+      properties:
+        code:
+          type: integer
+        message:
+          type: string
+required:
+  - code
+  - message

--- a/components/security/bearerAuth.yaml
+++ b/components/security/bearerAuth.yaml
@@ -1,0 +1,2 @@
+type: http
+scheme: bearer

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   title: KABU & PLUS API
   version: 0.0.1

--- a/openapi.yml
+++ b/openapi.yml
@@ -11,7 +11,7 @@ components:
       $ref: "./components/parameters/mzArticleId.yml"
   responses:
     Error:
-      $ref: "./components/responses/Error.yml"
+      $ref: "./components/schemas/Error.yml"
   securitySchemes:
     bearerAuth:
       $ref: "./components/security/bearerAuth.yaml"

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,0 +1,17 @@
+openapi: 3.0.3
+info:
+  title: KABU & PLUS API
+  version: 0.0.1
+paths:
+  /mz-articles/{mzArticleId}/bookmark:
+    $ref: "./paths/mz-articles/bookmark.yml"
+components:
+  parameters:
+    mzArticleId:
+      $ref: "./components/parameters/mzArticleId.yml"
+  responses:
+    Error:
+      $ref: "./components/responses/Error.yml"
+  securitySchemes:
+    bearerAuth:
+      $ref: "./components/security/bearerAuth.yaml"

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,6 +1,6 @@
 openapi: 3.1.0
 info:
-  title: KABU & PLUS API
+  title: kabu-community API
   version: 0.0.1
 paths:
   /mz-articles/{mzArticleId}/bookmark:

--- a/paths/mz-articles/bookmark.yml
+++ b/paths/mz-articles/bookmark.yml
@@ -19,6 +19,15 @@ post:
       $ref: "../../components/responses/Unauthorized.yml"
     "404":
       $ref: "../../components/responses/NotFound.yml"
+    "409":
+      description: Conflict
+      content:
+        application/json:
+          schema:
+            $ref: "../../components/schemas/Error.yml"
+          example:
+            code: 1
+            message: "Conflict - Article already bookmarked."
     "500":
       $ref: "../../components/responses/InternalServerError.yml"
   security:

--- a/paths/mz-articles/bookmark.yml
+++ b/paths/mz-articles/bookmark.yml
@@ -13,10 +13,10 @@ post:
               message:
                 type: string
                 example: "Bookmark added successfully."
-    "401":
-      $ref: "../../components/responses/Unauthorized.yml"
     "400":
       $ref: "../../components/responses/BadRequest.yml"
+    "401":
+      $ref: "../../components/responses/Unauthorized.yml"
     "404":
       $ref: "../../components/responses/NotFound.yml"
     "500":
@@ -32,10 +32,10 @@ delete:
       description: Bookmark removed successfully
     "401":
       $ref: "../../components/responses/Unauthorized.yml"
-    "404":
-      $ref: "../../components/responses/NotFound.yml"
     "403":
       $ref: "../../components/responses/Forbidden.yml"
+    "404":
+      $ref: "../../components/responses/NotFound.yml"
     "500":
       $ref: "../../components/responses/InternalServerError.yml"
   security:

--- a/paths/mz-articles/bookmark.yml
+++ b/paths/mz-articles/bookmark.yml
@@ -1,0 +1,42 @@
+post:
+  summary: Add a bookmark to an article
+  parameters:
+    - $ref: "../../components/parameters/mzArticleId.yml"
+  responses:
+    "201":
+      description: Bookmark added successfully
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: "Bookmark added successfully."
+    "401":
+      $ref: "../../components/responses/Unauthorized.yml"
+    "400":
+      $ref: "../../components/responses/BadRequest.yml"
+    "404":
+      $ref: "../../components/responses/NotFound.yml"
+    "500":
+      $ref: "../../components/responses/InternalServerError.yml"
+  security:
+    - bearerAuth: []
+delete:
+  summary: Remove a bookmark from an article
+  parameters:
+    - $ref: "../../components/parameters/mzArticleId.yml"
+  responses:
+    "204":
+      description: Bookmark removed successfully
+    "401":
+      $ref: "../../components/responses/Unauthorized.yml"
+    "404":
+      $ref: "../../components/responses/NotFound.yml"
+    "403":
+      $ref: "../../components/responses/Forbidden.yml"
+    "500":
+      $ref: "../../components/responses/InternalServerError.yml"
+  security:
+    - bearerAuth: []


### PR DESCRIPTION
## 概要

MZ記事ブックマークAPIをざっくり定義して見ました。こんな感じで問題ないかご確認お願いします。

細かいところでも一旦コメントいただけるとありがたいです。

```
/
├── components/
│   ├── parameters/
│   ├── responses/
│   ├── schemas/
│   └── security/
├── paths/
│   └── mz-articles/
│       └── bookmark.yml # ブックマークAPIの定義(ディレクトリ構成要検討)
└── openapi.yml          # ルートファイル。components,pathsを参照して組み立てる。
```

### 確認したいこと

- 仮でリポジトリ作ったが、openapi.ymlを管理するリポジトリ決まっているか。（早めにアクセス制限掛けたリポジトリに移動したい）